### PR TITLE
Added install instructions to the README with dependencies copied fro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Yabar is a modern and lightweight status bar that is intended to be used along w
 
 A Yabar session should contain one or more *bars* within the same session. Each bar should contain one or more *blocks*. Each block should display some useful info to the user (free memory, CPU temperature, etc...).
 
+## Installation
+Yabar requires libconfig, cairo, and pango. These dependencies can be installed through your distribution's package manager, such as `dnf install libconfig-devel cairo-devel pango-devel` on Fedora or `apt-get install libconfig-dev cairo-dev pango-dev` on Ubuntu.
+
+Once these are installed, running `make` will output the yabar executable. Copy this onto your PATH (`sudo cp yabar /usr/local/bin`) to install yabar globally on your system.
+
 ## Configuration
 
 Yabar currently by default accepts configuration from the config file `~/.config/yabar/yabar.conf` or using `yabar -c [CONFIG_FILE]`. The config file should like something like this:


### PR DESCRIPTION
Yabar was missing installation instructions and I was only able to get it to build by looking in Issues and finding a list of dependencies there by chance. After installing these I was able to build Yabar. I decided to take 2 minutes and go ahead and add those instructions to the README for anyone who comes after me.