### PR TITLE
spelling error in example config file

### DIFF
--- a/examples/example.config
+++ b/examples/example.config
@@ -8,7 +8,7 @@ topbar:{
 	height: 20; 
 	background-color-argb: 0x0;
 	underline-size: 2;
-	oveerline-size: 0;
+	overline-size: 0;
 	slack-size: 4;
 	title:{
 		exec: "xtitle -s";


### PR DESCRIPTION
Not a big change, but if people copy and paste the config, it wouldn't work off the bat.