### PR TITLE
Prevents extra space in battery block if not using indicators.

### DIFF
--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -474,7 +474,7 @@ void ya_int_battery(ya_block_t *blk) {
 			strcpy(startstr, bat_75str);
 		else
 			strcpy(startstr, bat_100str);
-		if(stat == 'C')
+		if(stat == 'C' && blk->internal->option[1])
 			strcat(strcat(startstr, " "), bat_chargestr);
 		sprintf(startstr+strlen(startstr), "%*d", space, bat);
 		if(suflen)


### PR DESCRIPTION
I apologize for creating a small mistake in the battery block; the original addition adds a space after the indicators even if there is no `internal-option2`. This commit makes sure that if one is not using `internal-option2` no extraneous space is added.