### PR TITLE
Changed Delimiter to Semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Yabar has a growing set of useful blocks. You can try out the sampe config locat
 
 		exec: "YABAR_BATTERY";
 		internal-option1: "BAT0"; #i.e. Replace NAME with your corresponding name
-		internal-option2: ";  ;  ;  ;  ";
+		internal-option2: " ;   ;   ;   ;  ";
 		internal-suffix: "%";
 		internal-spacing: true;
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Yabar has a growing set of useful blocks. You can try out the sampe config locat
 
 		exec: "YABAR_THERMAL";
 		internal-option1: "thermal_zone0"; #i.e. Replace `NAME` with your corresponding name
-		internal-option2: "70 0xFFFFFFFF 0xFFED303C"; #Critical Temperature, fg, bg
-		internal-option3: "58 0xFFFFFFFF 0xFFF4A345"; #Warning Temperature, fg, bg
+		internal-option2: "70; 0xFFFFFFFF; 0xFFED303C"; #Critical Temperature, fg, bg
+		internal-option3: "58; 0xFFFFFFFF; 0xFFF4A345"; #Warning Temperature, fg, bg
 		interval: 1;
 
 * Brightness: It checks out the brightness value in the file `/sys/class/backlight/NAME/brightness`. Example:
@@ -269,7 +269,7 @@ Yabar has a growing set of useful blocks. You can try out the sampe config locat
 
 		exec: "YABAR_BANDWIDTH";
 		internal-option1: "enp2s0"; #i.e. Replace NAME with your corresponding name
-		internal-option2: " "; #Two Strings (usually 2 font icons) to be injected before down/up values
+		internal-option2: "; "; #Two Strings (usually 2 font icons) to be injected before down/up values
 		interval: 2;
 
 * Used RAM: It checks out the file `/proc/meminfo` and then computes the total used memory. Example:
@@ -289,14 +289,14 @@ Yabar has a growing set of useful blocks. You can try out the sampe config locat
 
 		exec: "YABAR_DISKIO";
 		internal-option1: "sda"; #i.e. Replace NAME with your corresponding name
-		internal-option2: " "; #Two Strings (usually 2 font icons) to be injected before down/up values
+		internal-option2: "; "; #Two Strings (usually 2 font icons) to be injected before down/up values
 		interval: 1;
 
 * Battery: (Added thanks to @NBonaparte!) It checks out the files `/sys/class/power_supply/NAME/capacity` and `/sys/class/power_supply/NAME/status` and extracts the capacity value. Example:
 
 		exec: "YABAR_BATTERY";
 		internal-option1: "BAT0"; #i.e. Replace NAME with your corresponding name
-		internal-option2: "        ";
+		internal-option2: ";  ;  ;  ;  ";
 		internal-suffix: "%";
 		internal-spacing: true;
 

--- a/examples/internal1.config
+++ b/examples/internal1.config
@@ -117,7 +117,7 @@ bar1:{
 		interval: 1;
 		internal-suffix: "%";
 		internal-option1: "BAT0";
-		internal-option2: ";  ;  ;  ;  ";
+		internal-option2: " ;   ;   ;   ;  ";
 		#internal-spacing: true;
 	}
 	ya_disk: {

--- a/examples/internal1.config
+++ b/examples/internal1.config
@@ -70,8 +70,8 @@ bar1:{
 		background-color-rgb:0x309292;
 		underline-color-rgb:0xE08E79;
 		internal-option1: "thermal_zone0"; #Get NAME from /sys/class/NAME/temp
-		internal-option2: "70 0xFFFFFFFF 0xFFED303C"; #Critical Temperature, fg, bg
-		internal-option3: "58 0xFFFFFFFF 0xFFF4A345"; #Warning Temperature, fg, bg
+		internal-option2: "70; 0xFFFFFFFF; 0xFFED303C"; #Critical Temperature, fg, bg
+		internal-option3: "58; 0xFFFFFFFF; 0xFFF4A345"; #Warning Temperature, fg, bg
 		internal-prefix: " ";
 		#internal-spacing: true;
 	}
@@ -93,7 +93,7 @@ bar1:{
 		interval: 1;
 		internal-prefix: " ";
 		internal-option1: "wlo1"; #Replace this with your network interface. Get it by using the command `ifconfig` or `ip addr show`
-		internal-option2: " "; #Use characters(usually utf characters as shown) to be placed before down/up data, separated by a space
+		internal-option2: "; "; #Use characters(usually utf characters as shown) to be placed before down/up data, separated by a space
 		#background-color-rgb:0x547980;
 		background-color-rgb:0x3EC9A7;
 		underline-color-rgb:0xD95B43;
@@ -117,7 +117,7 @@ bar1:{
 		interval: 1;
 		internal-suffix: "%";
 		internal-option1: "BAT0";
-		internal-option2: "        ";
+		internal-option2: ";  ;  ;  ;  ";
 		#internal-spacing: true;
 	}
 	ya_disk: {
@@ -127,7 +127,7 @@ bar1:{
 		interval: 1;
 		internal-prefix: " ";
 		internal-option1: "sda"; #Get NAME from /sys/class/block/NAME/stat
-		internal-option2: " "; #Use characters(usually utf characters as shown) to be placed before down/up data, separated by a space
+		internal-option2: "; "; #Use characters(usually utf characters as shown) to be placed before down/up data, separated by a space
 		background-color-rgb:0x49708A;
 		underline-color-rgb:0xECD078;
 		#internal-spacing: true;

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -484,8 +484,8 @@ void ya_int_battery(ya_block_t *blk) {
 			strcpy(startstr, bat_75str);
 		else
 			strcpy(startstr, bat_100str);
-		if(stat == 'C' && blk->internal->option[1])
-			strcat(strcat(startstr, " "), bat_chargestr);
+		if((stat == 'C' || stat == 'U') && bat != 100)
+			strcat(startstr, bat_chargestr);
 		sprintf(startstr+strlen(startstr), "%*d", space, bat);
 		if(suflen)
 			strcat(blk->buf, blk->internal->suffix);

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -113,13 +113,13 @@ void ya_int_thermal(ya_block_t *blk) {
 	snprintf(fpath, 128, "/sys/class/thermal/%s/temp", blk->internal->option[0]);
 
 	if((blk->internal->option[1]==NULL) ||
-			(sscanf(blk->internal->option[1], "%d %x %x", &crttemp, &crtfg, &crtbg)!=3)) {
+			(sscanf(blk->internal->option[1], "%d; %x; %x", &crttemp, &crtfg, &crtbg)!=3)) {
 		crttemp = 70;
 		crtbg = 0xFFED303C;
 		crtfg = blk->fgcolor;
 	}
 	if((blk->internal->option[2]==NULL) ||
-			(sscanf(blk->internal->option[2], "%d %x %x", &wrntemp, &wrnfg, &wrnbg)!=3)) {
+			(sscanf(blk->internal->option[2], "%d; %x; %x", &wrntemp, &wrnfg, &wrnbg)!=3)) {
 		wrntemp = 58;
 		wrnbg = 0xFFF4A345;
 		wrnfg = blk->fgcolor;
@@ -223,7 +223,7 @@ void ya_int_bandwidth(ya_block_t * blk) {
 	snprintf(rxpath, 128, "/sys/class/net/%s/statistics/rx_bytes", blk->internal->option[0]);
 	snprintf(txpath, 128, "/sys/class/net/%s/statistics/tx_bytes", blk->internal->option[0]);
 	if(blk->internal->option[1]) {
-		sscanf(blk->internal->option[1], "%s %s", dnstr, upstr);
+		sscanf(blk->internal->option[1], "%[^;]; %[^;]", dnstr, upstr);
 	}
 	rxfile = fopen(rxpath, "r");
 	txfile = fopen(txpath, "r");
@@ -391,7 +391,7 @@ void ya_int_diskio(ya_block_t *blk) {
 	else
 		space = 0;
 	if(blk->internal->option[1]) {
-		sscanf(blk->internal->option[1], "%s %s", dnstr, upstr);
+		sscanf(blk->internal->option[1], "%[^;]; %[^;]", dnstr, upstr);
 	}
 	snprintf(tpath, 100, "/sys/class/block/%s/stat", blk->internal->option[0]);
 	tfile = fopen(tpath, "r");
@@ -451,7 +451,7 @@ void ya_int_battery(ya_block_t *blk) {
 	snprintf(cpath, 128, "/sys/class/power_supply/%s/capacity", blk->internal->option[0]);
 	snprintf(spath, 128, "/sys/class/power_supply/%s/status", blk->internal->option[0]);
 	if(blk->internal->option[1]) {
-		sscanf(blk->internal->option[1], "%s %s %s %s %s", bat_25str, bat_50str, bat_75str, bat_100str, bat_chargestr);
+		sscanf(blk->internal->option[1], "%[^;]; %[^;]; %[^;]; %[^;]; %[^;]", bat_25str, bat_50str, bat_75str, bat_100str, bat_chargestr);
 	}
 	cfile = fopen(cpath, "r");
 	sfile = fopen(spath, "r");


### PR DESCRIPTION
The current delimiter prevents use of the space as part of an internal option string; using span tags like `<span foreground="blue">` would be chopped in half and extra spaces (for spacing) would be omitted. Switching to semicolons prevents this from happening.

As an added bonus, the extra space appended in the battery block is no longer needed, as the user can now control the spacing.

The battery charging logic has also been changed to accommodate for the "Unknown" status occasionally appearing when charging on older laptops.