### PR TITLE
add env variables for click position in block

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ The spaces are just skipped automatically. Keep in mind that You can always dyna
 
 ### Environment variables
 
-Yabar sets a handful of environment variables before executing your commands/scripts that are defined in the `command-button{1-5}` entry. Such env variables can be useful when drawing your window on the corresponding button press. Current env variables are:
+Yabar sets a handful of environment variables before executing your commands/scripts that are defined in the `command-button{1-5}` entry. Such env variables can be useful when drawing your window on the corresponding button press or determining where the click occured. Current env variables are:
 
 		${YABAR_BLOCK_X} #The beginning x axis for the block
 		${YABAR_BLOCK_Y} #It returns just the bottom y value of the block in case of topbar or just the top y value of the block in case of bottombar
 		${YABAR_BLOCK_WIDTH} #Block width
+		${YABAR_CLICK_X} #The x coordinate of the click starting in the top-left corner of the block
+		${YABAR_CLICK_Y} #The y coordinate of the click starting in the top-left corner of the block
 
 ## Internal blocks
 

--- a/src/ya_exec.c
+++ b/src/ya_exec.c
@@ -441,7 +441,7 @@ inline void ya_exec_button(ya_block_t * blk, xcb_button_press_event_t *eb) {
 	if (fork() == 0) {
 #ifdef YA_ENV_VARS
 		//Setup environment variables.
-		char blkx[6], blky[6], blkw[6];
+		char blkx[6], blky[6], blkw[6], clkx[6], clky[6];
 		snprintf(blkx, 6, "%d", eb->root_x - eb->event_x + blk->shift);
 		if (blk->bar->position == YA_TOP)
 			snprintf(blky, 6, "%d", blk->bar->height + blk->bar->vgap);
@@ -451,9 +451,17 @@ inline void ya_exec_button(ya_block_t * blk, xcb_button_press_event_t *eb) {
 			//TODO for right and left
 		}
 		snprintf(blkw, 6, "%d", blk->width);
+		if ((blk->bar->position == YA_TOP) || (blk->bar->position == YA_BOTTOM)) {
+			snprintf(clkx, 6, "%d", eb->event_x - blk->shift);
+			snprintf(clky, 6, "%d", eb->event_y);
+		} else {
+			//TODO for right and left
+		}
 		setenv("YABAR_BLOCK_X", blkx, 1);
 		setenv("YABAR_BLOCK_Y", blky, 1);
 		setenv("YABAR_BLOCK_WIDTH", blkw, 1);
+		setenv("YABAR_CLICK_X", clkx, 1);
+		setenv("YABAR_CLICK_Y", clky, 1);
 #endif
 		execl(yashell, yashell, "-c", blk->button_cmd[eb->detail-1], (char *) NULL);
 		_exit(EXIT_SUCCESS);


### PR DESCRIPTION
Add two new environment variables to button commands:

```
${YABAR_CLICK_X} #Click x position
${YABAR_CLICK_Y} #Click y position
```

They represent the relative x and y coordinates of the click in the block (top-left corner).

This should help scripts, which need the know the exact position of the click, like an i3 workspace switcher.
