### PR TITLE
Fix format error warning when compiling

### DIFF
--- a/src/ya_parse.c
+++ b/src/ya_parse.c
@@ -120,8 +120,7 @@ static int ya_inherit_blk(ya_block_t *dstb, const char *name) {
 	ya_block_t *srcb;
 	int nlen = strlen(name);
 	if(nlen < 1) {
-		fprintf(stderr, "No inherit entry. ");
-		fprintf(stderr, per);
+		fprintf(stderr, "No inherit entry. %s", per);
 		return -1;
 	}
 	for(int i = 0; i < nlen; i++) {
@@ -131,7 +130,7 @@ static int ya_inherit_blk(ya_block_t *dstb, const char *name) {
 		}
 	}
 	if(barnamelen == 0) {
-		fprintf(stderr, per);
+		fprintf(stderr, "%s", per);
 		return -1;
 	}
 


### PR DESCRIPTION
Previously, when compiling with default settings for Debian Packages,
building was impossible (specifically due to `-Werror=format-security`)

```
cc -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -std=c99 -Iinclude -pedantic -Wall -Os `pkg-config --cflags pango pangocairo libconfig` -Wdate-time -D_FORTIFY_SOURCE=2
-DVERSION=\"0.4.0-1-g44211c1\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DYA_DYN_COL -DYA_ENV_VARS -DYA_INTERNAL_EWMH  -c -o src/ya_parse.o src/ya_parse.c
src/ya_parse.c: In function ‘ya_inherit_blk’:
src/ya_parse.c:116:3: error: format not a string literal and no format arguments [-Werror=format-security]
   fprintf(stderr, per);
   ^
src/ya_parse.c:126:3: error: format not a string literal and no format arguments [-Werror=format-security]
   fprintf(stderr, per);
   ^
cc1: some warnings being treated as errors
<builtin>: recipe for target 'src/ya_parse.o' failed
```