### PR TITLE
Add Missing Cleanup to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ uninstall:
 	rm -f "$(DESTDIR)$(BINPREFIX)/$(PROGRAM)"
 	rm -f "$(DESTDIR)$(MANPREFIX)"/man1/yabar.1
 clean:
-	rm -f src/*.o $(PROGRAM)
+	rm -f src/*.o src/intern_blks/*.o $(PROGRAM)
 
 .PHONY: all install uninstall clean


### PR DESCRIPTION
The Makefile builds object files in `src/` and `src/intern_blks/`,
however the clean target only deleted object files inside `src/`

Now the `clean` target deletes object files in `src/`, `src/intern_blks/`
and the program itself