### PR TITLE
Make VERSION in Makefile externally overwriteable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = $(shell git describe)
+VERSION ?= $(shell git describe)
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DYA_DYN_COL \
 			-DYA_ENV_VARS -DYA_INTERNAL_EWMH -DYA_ICON -DYA_NOWIN_COL -DYA_MUTEX -DYA_VAR_WIDTH
 CFLAGS += -std=c99 -Iinclude -pedantic -Wall -Os `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0`


### PR DESCRIPTION
For various enviroment it is very valuable to have externally
overwriteable versions (such as distribution packaging, where
a maintainer wants to set a specfic version).
Also, not all build enviroments have git available (e.g. Debian),
therefore the expression `$(shell git describe)` would be evaluated
to "" (nothing).