### PR TITLE
Bandwidth blk : 'default' option1

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Yabar has a growing set of useful blocks. You can try out the sampe config locat
 * Network bandwidth: It checks out the total transmitted and received bytes in the files `/sys/class/net/NAME/statistics/tx_bytes` and `/sys/class/net/NAME/statistics/rx_bytes` and convert them to rates. Example:
 
 		exec: "YABAR_BANDWIDTH";
-		internal-option1: "enp2s0"; #i.e. Replace NAME with your corresponding name
+		internal-option1: "default"; #Possible values are 'default' or any interface name (e.g. 'eth0', 'wlan1')
 		internal-option2: " "; #Two Strings (usually 2 font icons) to be injected before down/up values
 		interval: 2;
 

--- a/doc/yabar.1
+++ b/doc/yabar.1
@@ -461,7 +461,7 @@ Network bandwidth: It checks out the total transmitted and received bytes in the
 
 .nf
 exec: "YABAR\_BANDWIDTH";
-internal\-option1: "enp2s0"; #i.e. Replace NAME with your corresponding name
+internal\-option1: "default"; #Possible values are 'default' or any interface name (e.g. 'eth0', 'wlan1')
 internal\-option2: " "; #Two Strings (usually 2 font icons) to be injected before down/up values
 interval: 2;
 

--- a/examples/internal1.config
+++ b/examples/internal1.config
@@ -92,7 +92,7 @@ bar1:{
 		fixed-size: 110;
 		interval: 1;
 		internal-prefix: " ";
-		internal-option1: "wlo1"; #Replace this with your network interface. Get it by using the command `ifconfig` or `ip addr show`
+		internal-option1: "default"; # This can be changed by a specific interface name, get it by using the command `ifconfig` or `ip addr show`
 		internal-option2: " "; #Use characters(usually utf characters as shown) to be placed before down/up data, separated by a space
 		#background-color-rgb:0x547980;
 		background-color-rgb:0x3EC9A7;

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -239,6 +239,7 @@ void ya_int_bandwidth(ya_block_t * blk) {
 				}
 			}
 		}
+		fclose(routefile);
 	} else {
 		strncpy(ifname, blk->internal->option[0], 16);
 	}

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -220,13 +220,30 @@ void ya_int_bandwidth(ya_block_t * blk) {
 	char *startstr = blk->buf;
 	size_t prflen=0,suflen=0;
 	char dnstr[20], upstr[20];
+	char ifname[16];
 	ya_setup_prefix_suffix(blk, &prflen, &suflen, &startstr);
 	if(blk->internal->spacing)
 		space = 4;
 	else
 		space = 0;
-	snprintf(rxpath, 128, "/sys/class/net/%s/statistics/rx_bytes", blk->internal->option[0]);
-	snprintf(txpath, 128, "/sys/class/net/%s/statistics/tx_bytes", blk->internal->option[0]);
+	if ( strncmp(blk->internal->option[0], "default", 7) == 0 ) {
+		FILE *routefile;
+		char line[100], *r_ifname, *r_dest;
+		routefile = fopen("/proc/net/route", "r");
+		while ( fgets(line, 100, routefile) != NULL ) {
+			r_ifname = strtok(line, "\t");
+			r_dest = strtok(NULL, "\t");
+			if ( r_ifname != NULL && r_dest != NULL) {
+				if ( strncmp(r_dest, "00000000", 8) == 0 ) {
+					strncpy(ifname, r_ifname, 16);
+				}
+			}
+		}
+	} else {
+		strncpy(ifname, blk->internal->option[0], 16);
+	}
+	snprintf(rxpath, 128, "/sys/class/net/%s/statistics/rx_bytes", ifname);
+	snprintf(txpath, 128, "/sys/class/net/%s/statistics/tx_bytes", ifname);
 	if(blk->internal->option[1]) {
 		sscanf(blk->internal->option[1], "%s %s", dnstr, upstr);
 	}


### PR DESCRIPTION
Add the possibility to set the internal-option1 of the bandwidth block to "default". The bandwidth will then be calculated for the interface used to reach the default gateway (default route 0.0.0.0/0).
