### PR TITLE
Move to optimizing for speed with LTO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ VERSION ?= $(shell git describe)
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DYA_DYN_COL \
 			-DYA_ENV_VARS -DYA_INTERNAL_EWMH -DYA_ICON -DYA_NOWIN_COL -DYA_MUTEX -DYA_VAR_WIDTH \
 			-DYA_BSPWM
-CFLAGS += -std=c99 -Iinclude -pedantic -Wall -Os `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
+CFLAGS += -std=c99 -Iinclude -pedantic -Wall -flto -O2 `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
+LDFLAGS += -flto -O2
 LDLIBS += -liw -lxcb -lpthread -lxcb-randr -lxcb-ewmh -lxcb-icccm -lm `pkg-config --libs pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
 PROGRAM := yabar
 DOCS := $(PROGRAM).1
@@ -17,7 +18,7 @@ OBJS := $(OBJS:.c=.o)
 	$(CC) $(CFLAGS) -c -o $@ $<
 all: $(PROGRAM) $(DOCS)
 $(PROGRAM): $(OBJS)
-	$(CC) -o $@ $^ $(LDLIBS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 docs: $(DOCS)
 install:
 	mkdir -p "$(DESTDIR)$(BINPREFIX)"


### PR DESCRIPTION
I am not sure about the reason to optimizing for size. I think better would be to optimize for speed with LTO enabled. 

If there's a reason for size optimization then, using LTO will improve that as well. Tested with both `clang` and `gcc`.