### PR TITLE
Remove duplicate const declaration.

### DIFF
--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -753,7 +753,7 @@ void ya_int_wifi(ya_block_t *blk) {
 
 
 /* -- Disk usage block -- */
-static const char const symbols[5] = {0, 'K', 'M', 'G', 'T'};
+static const char symbols[5] = {0, 'K', 'M', 'G', 'T'};
 //bytes to human-readable str: convert an amount of bytes to a string with the
 //corresponding suffix. e.g. "123456789" -> "117.7M" (bytes)
 


### PR DESCRIPTION
This is regarding one of the warnings that both `gcc` and `clang` report:
```
cc -std=c99 -Iinclude -pedantic -Werror -Wall -Os `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0 alsa` -DVERSION=\"0.4.0-147-gce1dea3\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DYA_DYN_COL -DYA_ENV_VARS -DYA_INTERNAL_EWMH -DYA_ICON -DYA_NOWIN_COL -DYA_MUTEX -DYA_VAR_WIDTH -DYA_BSPWM  -c -o src/intern_blks/ya_intern.o src/intern_blks/ya_intern.c
src/intern_blks/ya_intern.c:756:19: error: duplicate ‘const’ declaration specifier [-Werror=duplicate-decl-specifier]
 static const char const symbols[5] = {0, 'K', 'M', 'G', 'T'};
                   ^~~~~
```