### PR TITLE
Append emptystring after charge/battery string

### DIFF
--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -551,6 +551,7 @@ void ya_int_battery(ya_block_t *blk) {
 		}
 		if(stat == 'C' && blk->internal->option[1])
 			strcat(strcat(startstr, " "), bat_chargestr);
+		strcat(startstr, " ");
 		sprintf(startstr+strlen(startstr), "%*d", space, bat);
 		if(suflen)
 			strcat(blk->buf, blk->internal->suffix);


### PR DESCRIPTION
The charge string and battery string are preferably unicode symbols
that clash with the actual battery status. A space between them
makes the battery status information more readable.