### PR TITLE
Integrate `playerctl` into the bar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,26 @@ matrix:
     - script: make yabar
       compiler: gcc
       language: c
+      sudo: required
+      env: CPPFLAGS=-DOLD_LIBCONFIG PLAYERCTL=1
+      addons:
+        apt:
+          packages:
+            - libxcb-randr0-dev
+            - libconfig-dev
+            - libcairo2-dev
+            - libpango1.0-dev
+            - libxcb-ewmh-dev
+            - libxcb-icccm4-dev
+            - libasound2-dev
+            - libiw-dev
+            - wget
+      before_install:
+        - wget https://github.com/acrisci/playerctl/releases/download/v0.5.0/playerctl-0.5.0_amd64.deb -O playerctl.deb
+        - sudo dpkg -i playerctl.deb
+    - script: make yabar
+      compiler: gcc
+      language: c
       env: CPPFLAGS=-DOLD_LIBCONFIG
       addons:
         apt:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,16 @@ CPPFLAGS += -DVERSION=\"$(VERSION)\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DY
 			-DYA_ENV_VARS -DYA_INTERNAL_EWMH -DYA_ICON -DYA_NOWIN_COL -DYA_MUTEX -DYA_VAR_WIDTH \
 			-DYA_BSPWM
 CFLAGS += -std=c99 -Iinclude -pedantic -Wall -flto -O2 `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
+
+DEPS += pango pangocairo libconfig gdk-pixbuf-2.0 alsa
+ifdef PLAYERCTL
+CFLAGS += -DPLAYERCTL
+CPPFLAGS += -DPLAYERCTL
+DEPS += playerctl-1.0
+endif
+
 LDFLAGS += -flto -O2
-LDLIBS += -liw -lxcb -lpthread -lxcb-randr -lxcb-ewmh -lxcb-icccm -lm `pkg-config --libs pango pangocairo libconfig gdk-pixbuf-2.0 alsa playerctl-1.0`
+LDLIBS += -liw -lxcb -lpthread -lxcb-randr -lxcb-ewmh -lxcb-icccm -lm `pkg-config --libs $(DEPS)`
 PROGRAM := yabar
 DOCS := $(PROGRAM).1
 PREFIX ?= /usr

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CPPFLAGS += -DVERSION=\"$(VERSION)\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DY
 			-DYA_BSPWM
 CFLAGS += -std=c99 -Iinclude -pedantic -Wall -flto -O2 `pkg-config --cflags pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
 LDFLAGS += -flto -O2
-LDLIBS += -liw -lxcb -lpthread -lxcb-randr -lxcb-ewmh -lxcb-icccm -lm `pkg-config --libs pango pangocairo libconfig gdk-pixbuf-2.0 alsa`
+LDLIBS += -liw -lxcb -lpthread -lxcb-randr -lxcb-ewmh -lxcb-icccm -lm `pkg-config --libs pango pangocairo libconfig gdk-pixbuf-2.0 alsa playerctl-1.0`
 PROGRAM := yabar
 DOCS := $(PROGRAM).1
 PREFIX ?= /usr

--- a/doc/yabar.1.asciidoc
+++ b/doc/yabar.1.asciidoc
@@ -328,6 +328,12 @@ internal-option2: "        "; # icons to indicate quarter, half, 
 internal-suffix: "%";
 ----
 
+* *YABAR_SONG* - *Current Song*: Uses 'playerctl' to retrieve the name of the currently played song. Example:
+----
+exec: "YABAR_SONG";
+internal-option1: "spotify";
+----
+
 * *YABAR_VOLUME* - *Volume*: Uses ALSA to display sound volume in percentage. Example:
 ----
 exec: "YABAR_VOLUME";

--- a/examples/example.config
+++ b/examples/example.config
@@ -199,4 +199,10 @@ topbar:{
 		foreground-color-rgb:0x92D8F0;
 		underline-color-rgb:0xc0b929;
 	}
+	song:{
+		exec: "YABAR_SONG";
+		fixed-size: 200;
+		type: "periodic";
+		internal-option1: "spotify";
+	}
 }

--- a/include/yabar.h
+++ b/include/yabar.h
@@ -119,9 +119,17 @@ enum {
 
 
 #ifdef YA_INTERNAL_EWMH
+#ifdef PLAYERCTL
+#define YA_INTERNAL_LEN 17
+#else
 #define YA_INTERNAL_LEN 16
+#endif
+#else
+#ifdef PLAYERCTL
+#define YA_INTERNAL_LEN 15
 #else
 #define YA_INTERNAL_LEN 14
+#endif
 #endif
 enum {
 	YA_INT_DATE = 0,
@@ -139,7 +147,8 @@ enum {
 	YA_INT_WIFI,
 	YA_INT_DISKSPACE,
 	YA_INT_TITLE,
-	YA_INT_WORKSPACE
+	YA_INT_WORKSPACE,
+	YA_INT_SONG
 };
 
 #define NOT_INHERIT_BAR(bar) (((bar)->attr & BARA_INHERIT)==0)

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,6 @@ with import <nixpkgs>{}; stdenv.mkDerivation {
 
   buildInputs = [
     cairo gdk_pixbuf libconfig pango pkgconfig xorg.xcbutilwm docbook_xsl
-    alsaLib wirelesstools asciidoc libxslt makeWrapper libxml2
+    alsaLib wirelesstools asciidoc libxslt makeWrapper libxml2 playerctl
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs>{}; stdenv.mkDerivation {
+  name = "yabar-dev";
+  src = ./.;
+
+  buildInputs = [
+    cairo gdk_pixbuf libconfig pango pkgconfig xorg.xcbutilwm docbook_xsl
+    alsaLib wirelesstools asciidoc libxslt makeWrapper libxml2
+  ];
+}

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -22,8 +22,10 @@ void ya_int_battery(ya_block_t *blk);
 void ya_int_volume(ya_block_t *blk);
 void ya_int_wifi(ya_block_t *blk);
 void ya_int_diskspace(ya_block_t *blk);
+void ya_int_song(ya_block_t *blk);
 
 struct reserved_blk ya_reserved_blks[YA_INTERNAL_LEN] = {
+	{"YABAR_SONG", ya_int_song},
 	{"YABAR_DATE", ya_int_date},
 	{"YABAR_UPTIME", ya_int_uptime},
 	{"YABAR_THERMAL", ya_int_thermal},
@@ -126,6 +128,66 @@ __attribute__ ((gnu_inline)) inline void ya_setup_prefix_suffix(ya_block_t *blk,
 	}
 	if(blk->internal->suffix) {
 		*suflen = strlen(blk->internal->suffix);
+	}
+}
+
+#include <playerctl/playerctl.h>
+#define CHECK_PLAYER_ERROR(PREFIX) \
+	if (PREFIX) \
+		ya_block_error(blk, "Player error!");
+
+#define PRINT_PAUSED_MSG() \
+	sprintf(startstr,"%s",blk->internal->option[2]);
+
+void ya_int_song(ya_block_t *blk) {
+	char *startstr = blk->buf;
+	size_t prflen = 0,suflen = 0;
+	ya_setup_prefix_suffix(blk, &prflen, &suflen, &startstr);
+
+	GError *e_tmp, *e_title, *e_artist;
+	PlayerctlPlayer *player;
+	gchar *s;
+
+	if (blk->internal->option[0]==NULL)
+		ya_block_error(blk, "Please set option0 for playerctl (e.g. spotify)!");
+	if (blk->internal->option[1]==NULL)
+		blk->internal->option[1] = " - ";
+	if (blk->internal->option[2]==NULL)
+		blk->internal->option[2] = "Paused";
+
+	while (1) {
+		player = playerctl_player_new(blk->internal->option[0], &e_tmp);
+		g_object_get(player, "status", &s, NULL);
+
+		if (s == NULL) {
+			PRINT_PAUSED_MSG();
+			continue;
+		}
+		if (strcmp("Playing", s) == 0) {
+			CHECK_PLAYER_ERROR(e_tmp);
+
+			sprintf(
+				startstr,
+				"%s %s %s",
+				playerctl_player_get_artist(player, &e_artist),
+				blk->internal->option[1],
+				playerctl_player_get_title(player, &e_title)
+			);
+
+			CHECK_PLAYER_ERROR(e_title);
+			CHECK_PLAYER_ERROR(e_artist);
+		} else {
+			PRINT_PAUSED_MSG();
+		}
+
+		if(suflen)
+			strcat(blk->buf, blk->internal->suffix);
+
+		g_free(s);
+		g_object_unref(player);
+
+		ya_draw_pango_text(blk);
+		sleep(blk->sleep);
 	}
 }
 

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -22,10 +22,15 @@ void ya_int_battery(ya_block_t *blk);
 void ya_int_volume(ya_block_t *blk);
 void ya_int_wifi(ya_block_t *blk);
 void ya_int_diskspace(ya_block_t *blk);
+
+#ifdef PLAYERCTL
 void ya_int_song(ya_block_t *blk);
+#endif
 
 struct reserved_blk ya_reserved_blks[YA_INTERNAL_LEN] = {
+#ifdef PLAYERCTL
 	{"YABAR_SONG", ya_int_song},
+#endif
 	{"YABAR_DATE", ya_int_date},
 	{"YABAR_UPTIME", ya_int_uptime},
 	{"YABAR_THERMAL", ya_int_thermal},
@@ -131,6 +136,7 @@ __attribute__ ((gnu_inline)) inline void ya_setup_prefix_suffix(ya_block_t *blk,
 	}
 }
 
+#ifdef PLAYERCTL
 #include <playerctl/playerctl.h>
 #define CHECK_PLAYER_ERROR(PREFIX) \
 	if (PREFIX) \
@@ -190,6 +196,7 @@ void ya_int_song(ya_block_t *blk) {
 		sleep(blk->sleep);
 	}
 }
+#endif
 
 #include <time.h>
 void ya_int_date(ya_block_t * blk) {


### PR DESCRIPTION
Provides simple support for playerctl and adds a `shell.nix` to make development on NixOS easier.