### PR TITLE
Fixed missprint

### DIFF
--- a/src/ya_exec.c
+++ b/src/ya_exec.c
@@ -18,7 +18,7 @@ static const char * const yashell = "/bin/sh";
 inline static void ya_copy_buf_from_index(ya_block_t *blk, uint32_t cur_desktop) {
 	char *cur = blk->internal->option[0];
 	uint32_t index =0;
-	for(;*cur!= '\0' && *cur == ' ';cur++);
+	for(;*cur == ' ';cur++);
 	for(;*cur != '\0'; cur++) {
 		int offset = 0;
 		if(*cur==' ')


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Errors, found using PVS-Studio:
yabar/src/ya_exec.c 21      err     V590 Consider inspecting the '* cur != '\\0' && * cur == ' '' expression. The expression is excessive or contains a misprint.