### PR TITLE
ya_int_song: improve configuration of playerctl properties

### DIFF
--- a/doc/yabar.1.asciidoc
+++ b/doc/yabar.1.asciidoc
@@ -332,6 +332,8 @@ internal-suffix: "%";
 ----
 exec: "YABAR_SONG";
 internal-option1: "spotify";
+internal-option2: "Paused";
+internal-option3: "title artist album";
 ----
 
 * *YABAR_VOLUME* - *Volume*: Uses ALSA to display sound volume in percentage. Example:


### PR DESCRIPTION
It's now possible to declare which properties from `playerctl`
(supported are `album`, `artist`, `title`) should be shown in the song
indicator. Before this, the usage of `<artist> - <title>` was hard-coded
which wasn't that usable if artist and/or title were quite long, now
it's up to the user what he wants to see.

The configuration can be used like this:

```
bar-list = ["bar"];
bar: {
  position: "top";
  block-list: ["ya_song"];
  ya_song: {
    exec: "YABAR_SONG";
    internal-option1: "spotify";
    internal-option3: "title artist album";
  }
}
```
  