### PR TITLE
support for playerctl-2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DEPS += pango pangocairo libconfig gdk-pixbuf-2.0 alsa
 ifdef PLAYERCTL
 CFLAGS += -DPLAYERCTL
 CPPFLAGS += -DPLAYERCTL
-DEPS += playerctl-1.0
+DEPS += playerctl
 endif
 
 LDFLAGS += -flto -O2


### PR DESCRIPTION
Apparently they renamed there pkg-config file.
Noticed in https://github.com/NixOS/nixpkgs/pull/52150