### PR TITLE
Fix buffer overflow in getting window title

### DIFF
--- a/src/ya_draw.c
+++ b/src/ya_draw.c
@@ -295,7 +295,7 @@ inline void ya_get_cur_window_title(ya_block_t * blk) {
 		wm_ck = xcb_ewmh_get_wm_name(ya.ewmh, ya.curwin);
 		wmvis_ck = xcb_ewmh_get_wm_visible_name(ya.ewmh, ya.curwin);
                 if(xcb_ewmh_get_wm_name_reply(ya.ewmh, wm_ck, &reply, NULL) == 1 || xcb_ewmh_get_wm_visible_name_reply(ya.ewmh, wmvis_ck, &reply, NULL) == 1) {
-			int len = GET_MIN(blk->bufsize, reply.strings_len);
+			int len = GET_MIN(blk->bufsize - 1, reply.strings_len);
 			strncpy(blk->buf, reply.strings, len);
 			blk->buf[len]='\0';
                 	xcb_ewmh_get_utf8_strings_reply_wipe(&reply);


### PR DESCRIPTION
I was having spontaneous crashes a while ago and had located this line as the problem. This seems to fix it (no further crashes, at least from what I've seen).